### PR TITLE
Move db uri to config

### DIFF
--- a/generators/app/templates/src/config/config.ts
+++ b/generators/app/templates/src/config/config.ts
@@ -5,17 +5,26 @@ const configs = {
     app: {
       name: '<%= kebabName %> (dev)'
     },
+    db: {
+      uri: 'my_uri'
+    },
     port: process.env.PORT || 3000
   },
   production: {
     app: {
       name: '<%= kebabName %>'
     },
+    db: {
+      uri: 'my_uri'
+    },
     port: process.env.PORT || 3000
   },
   test: {
     app: {
       name: '<%= kebabName %> (test)'
+    },
+    db: {
+      uri: 'my_uri'
     },
     port: process.env.PORT || 3000
   }

--- a/generators/service/templates/sequelize-connection-service.ts
+++ b/generators/service/templates/sequelize-connection-service.ts
@@ -1,9 +1,11 @@
 import { Service } from '@foal/core';
 import { SequelizeConnectionService } from '@foal/sequelize';
 
+import { config } from 'path/to/config';
+
 @Service()
 export class <%= CamelName %>Service extends SequelizeConnectionService {
   constructor() {
-    super('my_uri');
+    super(config.db.uri);
   }
 }


### PR DESCRIPTION
DB uri shouldn't appear in the sequelize connection class but in a config file.