### PR TITLE
Improve npm scripts

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -61,6 +61,7 @@ module.exports = class extends Generator {
   install() {
     this.npmInstall([], {}, () => {}, { cwd: this.names.kebabName });
     this.npmInstall([
+      'concurrently',
       'nodemon',
       'mocha',
       'chai',

--- a/generators/app/templates/package.json
+++ b/generators/app/templates/package.json
@@ -3,13 +3,12 @@
   "version": "0.0.0",
   "description": "",
   "scripts": {
-    "compile": "tsc",
-    "dev-compile": "tsc -w",
     "lint": "tslint -p tslint.json",
-    "start": "node ./dist/main.js",
-    "dev-start": "nodemon ./dist/main.js",
+    "build": "tsc",
     "test": "mocha \"./dist/**/*.spec.js\"",
-    "dev-test": "mocha -w \"./dist/**/*.spec.js\""
+    "start": "node ./dist/main.js",
+    "dev:app": "tsc && concurrently -p \"[{name}]\" -n \"BUILD,SERVER\" -c \"bold\" \"tsc -w\" \"nodemon -e js ./dist/main.js\"",
+    "dev:test": "tsc && concurrently -p \"[{name}]\" -n \"BUILD,SERVER\" -c \"bold\" \"tsc -w\" \"mocha -w \"./dist/**/*.spec.js\"\""
   },
   "dependencies": {
     "body-parser": "^1.18.2",


### PR DESCRIPTION
# Issue

Terminal commands for getting started and for developing should be easy.

# Solution

- [x] Rename `npm run compile` to `npm run build` (future builds may consist of more than a single compilation)
- [x] Replace `npm run dev-compile` and `npm run dev-start` with `npm run dev:app` to have only one command and one terminal.
- [x] Replace `npm run dev-build` and `npm run dev-test` with `npm run dev:test` to have only one command and one terminal.