### PR TITLE
Upgrade to es2017 et node8

### DIFF
--- a/generators/app/templates/package.json
+++ b/generators/app/templates/package.json
@@ -10,6 +10,9 @@
     "dev:app": "tsc && concurrently -p \"[{name}]\" -n \"BUILD,SERVER\" -c \"bold\" \"tsc -w\" \"nodemon -r source-map-support/register -e js ./dist/main.js\"",
     "dev:test": "tsc && concurrently -p \"[{name}]\" -n \"BUILD,SERVER\" -c \"bold\" \"tsc -w\" \"mocha -r source-map-support/register -w \"./dist/**/*.spec.js\"\""
   },
+  "engines": {
+    "node": ">=8"
+  },
   "dependencies": {
     "body-parser": "^1.18.2",
     "express": "^4.16.2",

--- a/generators/app/templates/tsconfig.json
+++ b/generators/app/templates/tsconfig.json
@@ -6,10 +6,10 @@
     "emitDecoratorMetadata": true,
     "strictNullChecks": true,
     "module": "commonjs",
-    "target": "es5",
+    "target": "es2017",
     "types": [ "mocha", "node" ],
     "lib": [
-      "es6",
+      "es2017",
       "dom"
     ]
   },


### PR DESCRIPTION
Starting from v0.4, foal packages require node version >= 8 (see https://github.com/FoalTS/foal/pull/35). We can now compile our project into es2017 then.