### PR TITLE
V0.4.0 alpha.2

### DIFF
--- a/generators/app/templates/package.json
+++ b/generators/app/templates/package.json
@@ -18,8 +18,8 @@
     "express": "^4.16.2",
     "helmet": "^3.9.0",
     "@types/node": "^8.0.47",
-    "@foal/core": "^0.4.0-alpha.0",
-    "@foal/common": "^0.4.0-alpha.0",
-    "@foal/express": "^0.4.0-alpha.0"
+    "@foal/core": "^0.4.0-alpha.2",
+    "@foal/common": "^0.4.0-alpha.2",
+    "@foal/express": "^0.4.0-alpha.2"
   }
 }

--- a/generators/app/templates/src/app/app.module.ts
+++ b/generators/app/templates/src/app/app.module.ts
@@ -2,5 +2,4 @@ import { FoalModule } from '@foal/core';
 
 export const AppModule: FoalModule = {
   controllers: [],
-  services: []
 };

--- a/generators/module/templates/module.ts
+++ b/generators/module/templates/module.ts
@@ -2,5 +2,4 @@ import { FoalModule } from '@foal/core';
 
 export const <%= CamelName %>Module: FoalModule = {
   controllers: [],
-  services: []
 };

--- a/generators/post-hook/templates/post-hook.spec.ts
+++ b/generators/post-hook/templates/post-hook.spec.ts
@@ -1,12 +1,14 @@
-import { PostMiddleware } from '@foal/core';
+import { createEmptyContext, getPostMiddleware, ServiceManager } from '@foal/core';
+import { expect } from 'chai';
 
-import { make<%= CamelName %>Middleware } from './<%= kebabName %>.post-hook';
+import { <%= camelName %> } from './<%= kebabName %>.post-hook';
 
-describe('make<%= CamelName %>Middleware', () => {
+describe('<%= camelName %>', () => {
 
-  let middleware: PostMiddleware;
+  it('should do something.', () => {
+    const middleware = getPostMiddleware(<%= camelName %>());
+    const ctx = createEmptyContext();
 
-  it('when it is called should return a middleware.', () => {
-    middleware = make<%= CamelName %>Middleware();
+    middleware(ctx, new ServiceManager());
   });
 });

--- a/generators/post-hook/templates/post-hook.ts
+++ b/generators/post-hook/templates/post-hook.ts
@@ -1,11 +1,7 @@
-import { Context, postHook, PostMiddleware } from '@foal/core';
-
-export function make<%= CamelName %>Middleware(): PostMiddleware {
-  return function <%= camelName %>Middleware(ctx: Context): void {
-
-  };
-}
+import { postHook } from '@foal/core';
 
 export function <%= camelName %>() {
-  return postHook(make<%= CamelName %>Middleware());
+  return postHook((ctx, services) => {
+
+  });
 }

--- a/generators/pre-hook/templates/pre-hook.spec.ts
+++ b/generators/pre-hook/templates/pre-hook.spec.ts
@@ -1,12 +1,14 @@
-import { PreMiddleware } from '@foal/core';
+import { createEmptyContext, getPreMiddleware, ServiceManager } from '@foal/core';
+import { expect } from 'chai';
 
-import { make<%= CamelName %>Middleware } from './<%= kebabName %>.pre-hook';
+import { <%= camelName %> } from './<%= kebabName %>.pre-hook';
 
-describe('make<%= CamelName %>Middleware', () => {
+describe('<%= camelName %>', () => {
 
-  let middleware: PreMiddleware;
+  it('should do something.', () => {
+    const middleware = getPreMiddleware(<%= camelName %>());
+    const ctx = createEmptyContext();
 
-  it('when it is called should return a middleware.', () => {
-    middleware = make<%= CamelName %>Middleware();
+    middleware(ctx, new ServiceManager());
   });
 });

--- a/generators/pre-hook/templates/pre-hook.ts
+++ b/generators/pre-hook/templates/pre-hook.ts
@@ -1,11 +1,7 @@
-import { Context, preHook, PreMiddleware } from '@foal/core';
-
-export function make<%= CamelName %>Middleware(): PreMiddleware {
-  return function <%= camelName %>Middleware(ctx: Context): void {
-
-  };
-}
+import { preHook } from '@foal/core';
 
 export function <%= camelName %>() {
-  return preHook(make<%= CamelName %>Middleware());
+  return preHook((ctx, services) => {
+
+  });
 }

--- a/generators/service/index.js
+++ b/generators/service/index.js
@@ -46,7 +46,7 @@ module.exports = class extends Generator {
 
   install() {
     if (['sequelize', 'sequelize-connection'].includes(this.type)) {
-      this.npmInstall([ '@foal/sequelize@0.4.0-alpha.0' ], { 'save': true });
+      this.npmInstall([ '@foal/sequelize@0.4.0-alpha.2' ], { 'save': true });
     }
   }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-foal",
-  "version": "0.3.3",
+  "version": "0.4.0-alpha.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-foal",
-  "version": "0.4.0-alpha.1",
+  "version": "0.4.0-alpha.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-foal",
-  "version": "0.4.0-alpha.1",
+  "version": "0.4.0-alpha.2",
   "description": "Yeoman generators to quickly start a project and create components (services, controllers, etc.)",
   "files": [
     "generators"


### PR DESCRIPTION
Update generator to support features of foal v0.4.0-alpha.2 (https://github.com/FoalTS/foal/pull/42).

- [x] Use getPreMiddleware and getPostMiddleware (https://github.com/FoalTS/generator-foal/pull/20).
- [x] Remove service declaration in modules (https://github.com/FoalTS/generator-foal/pull/21).