### PR TITLE
Use node env variable for URI by default.

### DIFF
--- a/generators/app/templates/src/config/config.ts
+++ b/generators/app/templates/src/config/config.ts
@@ -8,7 +8,7 @@ const configs = {
       name: '<%= kebabName %> (dev)'
     },
     db: {
-      uri: 'my_uri'
+      uri: process.env.DB_URI || 'my_uri'
     },
     errors: {
       logs: '500' as logOptions,
@@ -27,7 +27,7 @@ const configs = {
       name: '<%= kebabName %>'
     },
     db: {
-      uri: 'my_uri'
+      uri: process.env.DB_URI || 'my_uri'
     },
     errors: {
       logErrors: '500' as logOptions,
@@ -54,7 +54,7 @@ const configs = {
       name: '<%= kebabName %> (test)'
     },
     db: {
-      uri: 'my_uri'
+      uri: process.env.DB_URI || 'my_uri'
     },
     errors: {
       logErrors: 'none' as logOptions,


### PR DESCRIPTION
DB URIs (which include password) should be specified in node environnement variables and not in the code.
  