### PR TITLE
Move `source-map-support` from dev dep to dep

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -104,7 +104,6 @@ module.exports = class extends Generator {
     this.npmInstall([], {}, () => {}, { cwd: this.names.kebabName });
     this.npmInstall([
       'concurrently',
-      'source-map-support',
       'nodemon',
       'mocha',
       'chai',

--- a/generators/app/templates/package.json
+++ b/generators/app/templates/package.json
@@ -21,6 +21,7 @@
     "@types/node": "^8.0.47",
     "@foal/core": "^0.4.0-alpha.3",
     "@foal/common": "^0.4.0-alpha.3",
-    "@foal/express": "^0.4.0-alpha.3"
+    "@foal/express": "^0.4.0-alpha.3",
+    "source-map-support": "^0.5.1"
   }
 }


### PR DESCRIPTION
source-map-support should not be a dev dependency since it has to be installed on prod.