### PR TITLE
Move source-map-support register to code.

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -76,6 +76,7 @@ module.exports = class extends Generator {
       'templates/index.html',
 
       'package.json',
+      'server.js',
       'tsconfig.json',
       'tslint.json',
     ];

--- a/generators/app/templates/package.json
+++ b/generators/app/templates/package.json
@@ -6,8 +6,8 @@
     "lint": "tslint -c tslint.json -p tsconfig.json",
     "build": "tsc",
     "test": "mocha -r source-map-support/register \"./dist/**/*.spec.js\"",
-    "start": "node -r source-map-support/register ./dist/main.js",
-    "dev:app": "tsc && concurrently -p \"[{name}]\" -n \"BUILD,SERVER\" -c \"bold\" \"tsc -w\" \"nodemon -r source-map-support/register -e js ./dist/main.js\"",
+    "start": "node ./dist/main.js",
+    "dev:app": "tsc && concurrently -p \"[{name}]\" -n \"BUILD,SERVER\" -c \"bold\" \"tsc -w\" \"nodemon -e js ./dist/main.js\"",
     "dev:test": "tsc && concurrently -p \"[{name}]\" -n \"BUILD,SERVER\" -c \"bold\" \"tsc -w\" \"mocha -r source-map-support/register -w \"./dist/**/*.spec.js\"\""
   },
   "engines": {

--- a/generators/app/templates/package.json
+++ b/generators/app/templates/package.json
@@ -6,8 +6,8 @@
     "lint": "tslint -c tslint.json -p tsconfig.json",
     "build": "tsc",
     "test": "mocha -r source-map-support/register \"./dist/**/*.spec.js\"",
-    "start": "node ./dist/main.js",
-    "dev:app": "tsc && concurrently -p \"[{name}]\" -n \"BUILD,SERVER\" -c \"bold\" \"tsc -w\" \"nodemon -e js ./dist/main.js\"",
+    "start": "node server.js",
+    "dev:app": "tsc && concurrently -p \"[{name}]\" -n \"BUILD,SERVER\" -c \"bold\" \"tsc -w\" \"nodemon -e js server.js\"",
     "dev:test": "tsc && concurrently -p \"[{name}]\" -n \"BUILD,SERVER\" -c \"bold\" \"tsc -w\" \"mocha -r source-map-support/register -w \"./dist/**/*.spec.js\"\""
   },
   "engines": {

--- a/generators/app/templates/server.js
+++ b/generators/app/templates/server.js
@@ -1,0 +1,2 @@
+require('source-map-support').install();
+require('./dist/main.js');

--- a/generators/app/templates/src/main.ts
+++ b/generators/app/templates/src/main.ts
@@ -1,3 +1,5 @@
+import 'source-map-support/register';
+
 import { Foal } from '@foal/core';
 import { getCallback, handleErrors } from '@foal/express';
 import * as bodyParser from 'body-parser';

--- a/generators/app/templates/src/main.ts
+++ b/generators/app/templates/src/main.ts
@@ -1,5 +1,3 @@
-import 'source-map-support/register';
-
 import { Foal } from '@foal/core';
 import { getCallback, handleErrors } from '@foal/express';
 import * as bodyParser from 'body-parser';


### PR DESCRIPTION
# Issue

Deploying the generated app to Azure is hard because `npm run start` is complex.

# Solution

- [x] Create a `server.js` file at the root directory.
- [x] Move `source-map-support/register` to `server.js`